### PR TITLE
chore: added description for computed properties

### DIFF
--- a/src/compoundData/computed/__tests__/getComputedData.test.js
+++ b/src/compoundData/computed/__tests__/getComputedData.test.js
@@ -7,6 +7,8 @@ test('getComputedData', () => {
     complexity: {
       value: 19.9,
       label: 'Complexity',
+      description:
+        'The complexity rating is computed using the <a href="https://pubs.acs.org/doi/abs/10.1021/ci00054a004">Bertz/Hendrickson/Ihlenfeldt formula</a> and gives a numerical estimate of how complex a molecule is.',
       reference: {
         description: 'Computed by Cactvs 3.4.6.11 (PubChem release 2019.06.18)',
       },
@@ -14,6 +16,8 @@ test('getComputedData', () => {
     tpsa: {
       value: 0,
       label: 'Topological Polar Surface Area',
+      description:
+        'The topological polar surface area is the surface sum over all polar atoms in a molecule. It is an important estimator of transport properties of drugs.',
       reference: {
         description: 'Computed by Cactvs 3.4.6.11 (PubChem release 2019.06.18)',
       },
@@ -22,6 +26,8 @@ test('getComputedData', () => {
     xLogP3: {
       value: 3.4,
       label: 'XLogP3',
+      description:
+        'The octanol water partiion coefficient can be used as estimate of  molecular hydrophobicity.',
       reference: {
         description: 'Computed by XLogP3 3.0 (PubChem release 2019.06.18)',
       },
@@ -29,6 +35,8 @@ test('getComputedData', () => {
     hydrogenBondDonorCount: {
       value: 0,
       label: 'Hydrogen Bond Donor Count',
+      description:
+        'The number of hydrogen bond donor atoms in the structure. A hydrogen bond donor site can contribute a H to hydrogen bond formation.',
       reference: {
         description: 'Computed by Cactvs 3.4.6.11 (PubChem release 2019.06.18)',
       },
@@ -36,6 +44,8 @@ test('getComputedData', () => {
     hydrogenBondAcceptorCount: {
       value: 0,
       label: 'Hydrogen Bond Acceptor Count',
+      description:
+        'The number of hydrogen bond acceptor atoms in the structure. A hydrogen bond acceptor has a lone pair that can form hydrogen bonds.',
       reference: {
         description: 'Computed by Cactvs 3.4.6.11 (PubChem release 2019.06.18)',
       },
@@ -43,6 +53,8 @@ test('getComputedData', () => {
     rotableBondCount: {
       value: 3,
       label: 'Rotatable Bond Count',
+      description:
+        'Rotable bonds are single bonds that are not part of a ring and for which, rotation around the bond changes the overall shape of the molecule.',
       reference: {
         description: 'Computed by Cactvs 3.4.6.11 (PubChem release 2019.06.18)',
       },
@@ -50,12 +62,14 @@ test('getComputedData', () => {
     heavyAtomCount: {
       value: 6,
       label: 'Heavy Atom Count',
-
+      description: 'The number of atoms except hydrogen in the molecule.',
       reference: { description: 'Computed by PubChem' },
     },
     formalCharge: {
       value: 0,
       label: 'Formal Charge',
+      description:
+        'The formal charge is the difference between the number of valence electrons of each atom and the number of electrons the atom is associated with (assuming that the electrons in each bond are split equally between the bonded atoms).',
       reference: { description: 'Computed by PubChem' },
     },
   });

--- a/src/compoundData/computed/getComplexity.js
+++ b/src/compoundData/computed/getComplexity.js
@@ -6,12 +6,12 @@ import { getNumberProperties } from './getNumberProperties.js';
  * @export
  * @param {Object} response of a compound data request to the PubChem API
  * @param {Object} options
- * @param {Boolean} options.returnReferences If true it also returns info about references, defaults to false.
  * @returns {ComputedData}
  */
 
-export function getComplexity(data, options = {}) {
-  const { returnReferences = false } = options;
-  const complexity = getNumberProperties(data, 'Complexity', returnReferences);
+export function getComplexity(data) {
+  const description =
+    'The complexity rating is computed using the <a href="https://pubs.acs.org/doi/abs/10.1021/ci00054a004">Bertz/Hendrickson/Ihlenfeldt formula</a> and gives a numerical estimate of how complex a molecule is.';
+  const complexity = getNumberProperties(data, 'Complexity', description);
   return complexity;
 }

--- a/src/compoundData/computed/getComputedDataSection.js
+++ b/src/compoundData/computed/getComputedDataSection.js
@@ -9,6 +9,8 @@ import jp from 'jsonpath';
  * @property {String} references.sourceName -
  * @property {String} references.name -
  * @property {String} references.description -
+ * @property {String} label - human readable name of the property
+ * @property {String} description - description of the property
  */
 
 export function getComputedDataSection(data) {

--- a/src/compoundData/computed/getFormalCharge.js
+++ b/src/compoundData/computed/getFormalCharge.js
@@ -9,6 +9,8 @@ import { getNumberProperties } from './getNumberProperties.js';
  */
 
 export function getFormalCharge(data) {
-  const formalCharge = getNumberProperties(data, 'Formal Charge');
+  const description =
+    'The formal charge is the difference between the number of valence electrons of each atom and the number of electrons the atom is associated with (assuming that the electrons in each bond are split equally between the bonded atoms).';
+  const formalCharge = getNumberProperties(data, 'Formal Charge', description);
   return formalCharge;
 }

--- a/src/compoundData/computed/getHeavyAtomCount.js
+++ b/src/compoundData/computed/getHeavyAtomCount.js
@@ -9,6 +9,11 @@ import { getNumberProperties } from './getNumberProperties.js';
  */
 
 export function getHeavyAtomCount(data) {
-  const heavyAtomCount = getNumberProperties(data, 'Heavy Atom Count');
+  const description = 'The number of atoms except hydrogen in the molecule.';
+  const heavyAtomCount = getNumberProperties(
+    data,
+    'Heavy Atom Count',
+    description,
+  );
   return heavyAtomCount;
 }

--- a/src/compoundData/computed/getHydrogenBondAcceptorCount.js
+++ b/src/compoundData/computed/getHydrogenBondAcceptorCount.js
@@ -9,9 +9,12 @@ import { getNumberProperties } from './getNumberProperties.js';
  */
 
 export function getHydrogenBondAcceptorCount(data) {
+  const description =
+    'The number of hydrogen bond acceptor atoms in the structure. A hydrogen bond acceptor has a lone pair that can form hydrogen bonds.';
   const hydrogenBondAcceptorCount = getNumberProperties(
     data,
     'Hydrogen Bond Acceptor Count',
+    description,
   );
   return hydrogenBondAcceptorCount;
 }

--- a/src/compoundData/computed/getHydrogenBondDonorCount.js
+++ b/src/compoundData/computed/getHydrogenBondDonorCount.js
@@ -9,9 +9,12 @@ import { getNumberProperties } from './getNumberProperties.js';
  */
 
 export function getHydrogenBondDonorCount(data) {
+  const description =
+    'The number of hydrogen bond donor atoms in the structure. A hydrogen bond donor site can contribute a H to hydrogen bond formation.';
   const hydrogenBondDonorCount = getNumberProperties(
     data,
     'Hydrogen Bond Donor Count',
+    description,
   );
   return hydrogenBondDonorCount;
 }

--- a/src/compoundData/computed/getNumberProperties.js
+++ b/src/compoundData/computed/getNumberProperties.js
@@ -1,13 +1,14 @@
 import { getComputedDataSection } from './getComputedDataSection.js';
 import { getComputedPropertySection } from './getComputedPropertySection.js';
 
-export function getNumberProperties(data, sectionName) {
+export function getNumberProperties(data, sectionName, description) {
   let output = {
     value: null,
     label: null,
     reference: {
       description: null,
     },
+    description: description,
   };
 
   try {

--- a/src/compoundData/computed/getRotableBondCount.js
+++ b/src/compoundData/computed/getRotableBondCount.js
@@ -9,6 +9,12 @@ import { getNumberProperties } from './getNumberProperties.js';
  */
 
 export function getRotableBondCount(data) {
-  const rotableBondCount = getNumberProperties(data, 'Rotatable Bond Count');
+  const description =
+    'Rotable bonds are single bonds that are not part of a ring and for which, rotation around the bond changes the overall shape of the molecule.';
+  const rotableBondCount = getNumberProperties(
+    data,
+    'Rotatable Bond Count',
+    description,
+  );
   return rotableBondCount;
 }

--- a/src/compoundData/computed/getTPSA.js
+++ b/src/compoundData/computed/getTPSA.js
@@ -9,6 +9,12 @@ import { getNumberProperties } from './getNumberProperties.js';
  */
 
 export function getTPSA(data) {
-  const tpsa = getNumberProperties(data, 'Topological Polar Surface Area');
+  const description =
+    'The topological polar surface area is the surface sum over all polar atoms in a molecule. It is an important estimator of transport properties of drugs.';
+  const tpsa = getNumberProperties(
+    data,
+    'Topological Polar Surface Area',
+    description,
+  );
   return tpsa;
 }

--- a/src/compoundData/computed/getxLogP3.js
+++ b/src/compoundData/computed/getxLogP3.js
@@ -9,6 +9,8 @@ import { getNumberProperties } from './getNumberProperties.js';
  */
 
 export function getxLogP3(data) {
-  const xLogP3 = getNumberProperties(data, 'XLogP3');
+  const description =
+    'The octanol water partiion coefficient can be used as estimate of  molecular hydrophobicity.';
+  const xLogP3 = getNumberProperties(data, 'XLogP3', description);
   return xLogP3;
 }


### PR DESCRIPTION
- remove one useless `return references` 
- clean up the `typedef` (label was not mentioned)
- added description for computed properties

will be useful for completing https://github.com/zakodium/c6h6-react/pull/11